### PR TITLE
Creating a sum type for the different models

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -19,89 +19,9 @@ async fn main() -> Result<()>{
     let bedrock_client = Client::new(&config);
 
     // VARIABLES
-    let question = "Who is Alan Ford, a comic book character?";
-
-    //let model_id = "meta.llama2-70b-chat-v1";
-    //let model_id = "cohere.command-text-v14";
-    let model_id = "anthropic.claude-v2";
-
-    let bedrock_call: BedrockCall = match model_id {
-        "meta.llama2-70b-chat-v1" => {
-            let llama2_body = Llama2Body::new(
-                // prompt
-                question.to_string(),
-                // temperature
-                1.0,
-                // p
-                0.1,
-                // max_gen_len
-                1024
-                );
-            BedrockCall::new(
-                llama2_body.convert_to_blob()?,
-                String::from("application/json"), 
-                // accept
-                String::from("*/*"), 
-                // model-id
-                model_id.to_string(),
-            )
-        },
-        "cohere.command-text-v14" => {
-            let cohere_body = CohereBody::new(
-                // prompt
-                question.to_string(),
-                // max tokens
-                500,
-                // temperature
-                1.0,
-                // p
-                0.1,
-                // k
-                1,
-                // stop sequences
-                Vec::new(),
-                // stream
-                true,
-                );
-
-            BedrockCall::new(
-                cohere_body.convert_to_blob()?,
-                String::from("application/json"), 
-                // accept
-                String::from("*/*"), 
-                // model-id
-                model_id.to_string(),
-            )
-        },
-        "anthropic.claude-v2" => {
-            let claude_body = ClaudeBody::new(
-                // prompt
-                format!("\n\nHuman: {}\n\nAssistant:", question).to_string(),
-                // temp
-                1.0,
-                // top p
-                1.0,
-                // top k
-                250,
-                // max tokens to sample
-                500,
-                // stop sequences
-                Vec::new(),
-            );
-
-            BedrockCall::new(
-                claude_body.convert_to_blob()?,
-                String::from("application/json"), 
-                // accept
-                String::from("*/*"), 
-                // model-id
-                model_id.to_string(),
-            )
-
-        },
-        &_ => todo!()
-    };
-
+    let question = "List all of the memes in the Weezer song 'pork and beans'";
+    let model_id = "anthropic.claude-v2"
+    let bedrock_call = q_to_bcs_with_defaults(&question, &model_id)
     utils::hello_header("Welcome to Bedrust");
 
     println!("----------------------------------------");

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,12 +3,12 @@ mod utils;
 use anyhow::Result;
 
 use aws_sdk_bedrockruntime::Client;
-use bedrust::CohereBody;
-use bedrust::Llama2Body;
+
 use bedrust::configure_aws;
 use bedrust::call_bedrock_stream;
-use bedrust::ClaudeBody;
-use bedrust::BedrockCall;
+use bedrust::ask_bedrock;
+
+
 
 #[tokio::main]
 async fn main() -> Result<()>{
@@ -19,15 +19,16 @@ async fn main() -> Result<()>{
     let bedrock_client = Client::new(&config);
 
     // VARIABLES
-    let question = "List all of the memes in the Weezer song 'pork and beans'";
-    let model_id = "anthropic.claude-v2"
-    let bedrock_call = q_to_bcs_with_defaults(&question, &model_id)
+    let question = "Which songs are listed in the classic dancing guy youtube video 'evolution of dance'";
+    let model_id = "anthropic.claude-v2";
+
     utils::hello_header("Welcome to Bedrust");
 
     println!("----------------------------------------");
     println!("Calling Model: {}", &model_id);
     println!("Question being asked: {}", &question);
     println!("----------------------------------------");
-    call_bedrock_stream(bedrock_client, bedrock_call).await?;
+    ask_bedrock(question.to_string(), model_id, bedrock_client).await?;
+
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,8 @@
 mod utils;
 
 use anyhow::Result;
-
 use aws_sdk_bedrockruntime::Client;
-
 use bedrust::configure_aws;
-use bedrust::call_bedrock_stream;
 use bedrust::ask_bedrock;
 
 
@@ -19,7 +16,7 @@ async fn main() -> Result<()>{
     let bedrock_client = Client::new(&config);
 
     // VARIABLES
-    let question = "Which songs are listed in the classic dancing guy youtube video 'evolution of dance'";
+    let question = "Which songs are listed in the youtube video 'evolution of dance'?";
     let model_id = "anthropic.claude-v2";
 
     utils::hello_header("Welcome to Bedrust");


### PR DESCRIPTION
In this pull request, I create a sum type for the different models. The idea is that, as new models are added, there will be a single source of truth. This will be the menu that you present to the user, all the values in `ArgModels`. Once an option is added to `ArgModels`, the compiler should tell us everything else to update to make sure it all works with the new model. Thank you @darko-mesaros for working on this one with me.