### PR TITLE
Cleanups & QOL improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - TODO: Ability to generate images
 - TODO: Better code testing
+- TODO: Handle longer pastes better
+
+## [0.7.2] - 2024-04-12
+### Added
+- Added the ability to pick any available model from a list when running bedrust if there is no default model configured or if you are running `--init`.
+
+### Changed
+- Quality of life improvements, and code cleanup
+- Better handling of AWS SDK errors
 
 ## [0.7.1] - 2024-03-31
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -520,7 +520,7 @@ dependencies = [
 
 [[package]]
 name = "bedrust"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anyhow",
  "aws-config",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -520,7 +520,7 @@ dependencies = [
 
 [[package]]
 name = "bedrust"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -530,6 +530,7 @@ dependencies = [
  "base64 0.22.0",
  "clap",
  "colored",
+ "dialoguer",
  "dirs",
  "figlet-rs",
  "futures",
@@ -806,6 +807,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "dialoguer"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "658bce805d770f407bc62102fca7c2c64ceef2fbcb2b8bd19d2765ce093980de"
+dependencies = [
+ "console",
+ "fuzzy-matcher",
+ "shell-words",
+ "thiserror",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1013,6 +1026,15 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "fuzzy-matcher"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54614a3312934d066701a80f20f15fa3b56d67ac7722b39eea5b4c9dd1d66c94"
+dependencies = [
+ "thread_local",
 ]
 
 [[package]]
@@ -2025,6 +2047,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shell-words"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2151,6 +2179,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
+dependencies = [
+ "cfg-if",
+ "once_cell",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ aws-types = "1.1.5"
 base64 = "0.22.0"
 clap = { version = "4.5.0", features = ["derive"] }
 colored = "2.1.0"
+dialoguer = { version = "0.11.0", default-features = false, features = ["fuzzy-select", "completion"] }
 dirs = "5.0.1"
 figlet-rs = "0.1.5"
 futures = "0.3.30"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "bedrust"
 description = "A command line tool to invoke and work with Large Language models on AWS, using Amazon Bedrock"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2021"
-authors = ["Darko Mesaros <d@rko.rs>"]
+authors = ["Darko Mesaros <d@rko.rs>", "Stephen Barr <stephen.barr@devfactory.com>", "Russel Cohen <rcoh@rcoh.me>"]
 license = "MIT OR Apache-2.0"
 keywords = ["aws", "generative-ai", "bedrock", "chatbot"]
 categories = ["command-line-utilities", "generative-ai"]

--- a/README.md
+++ b/README.md
@@ -73,14 +73,15 @@ Let's initialize the configuration. Because **bedrust** uses two configuration f
 ```
 bedrust --init
 ```
-This will create all the necessary files for you to be able to use **bedrust**. There is no need to modify these files, unless you want to.
+You will get asked to pick a default model. And this will create all the necessary files for you to be able to use **bedrust**. There is no need to modify these files, unless you want to.
 
 ### Running the application 🚀
 
-Finally, to run the application just use the following `cargo` command:
+Finally, to run the application just use the following command:
 ```bash
 bedrust -m <MODELNAME> # replacing the model name with one of the supported ones
 ```
+Or if you wish to use the default model (the one defined during `--init` / in your config file) just run `bedrust` without any parameters. If you do not select a model by passing the `-m` parameter, AND you do not have a default model set in your config file, you will be prompted to pick one during the run.
 
 ## Usage
 ```bash
@@ -149,3 +150,4 @@ They *need* to be in your `$HOME/.config/bedrust/` directory. The application wi
 - [ ] Code Testing
 - [ ] Ability to generate images
 - [x] Make it prettier
+- [ ] Handle long pastes better

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,16 +1,18 @@
 pub mod captioner;
+pub mod constants;
 pub mod models;
 pub mod utils;
-pub mod constants;
 
 use anyhow::anyhow;
 use aws_config::meta::region::RegionProviderChain;
 use aws_config::BehaviorVersion;
 use aws_types::region::Region;
 use core::panic;
+use models::cohere::Blobbable;
 use serde::ser::Error;
 use serde::Deserialize;
 use serde_json::Value;
+
 use std::{env, io};
 
 use anyhow::Result;
@@ -34,17 +36,18 @@ use std::io::Write;
 use crate::captioner::Image;
 
 //======================================== AWS
-pub async fn configure_aws(s: String, p: String) -> aws_config::SdkConfig {
+pub async fn configure_aws(fallback_region: String, profile_name: String) -> aws_config::SdkConfig {
     let region_provider =
+        // NOTE: this is different than the default Rust SDK behavior which checks AWS_REGION first. Is this intentional?
         RegionProviderChain::first_try(env::var("AWS_DEFAULT_REGION").ok().map(Region::new))
             .or_default_provider()
-            .or_else(Region::new(s));
-
+            .or_else(Region::new(fallback_region));
 
     aws_config::defaults(BehaviorVersion::latest())
-        .credentials_provider(aws_config::profile::ProfileFileCredentialsProvider::builder()
-            .profile_name(p)
-            .build()
+        .credentials_provider(
+            aws_config::profile::ProfileFileCredentialsProvider::builder()
+                .profile_name(profile_name)
+                .build(),
         )
         .region(region_provider)
         .load()
@@ -61,13 +64,19 @@ pub enum RunType {
 #[derive(Debug)]
 struct BedrockCall {
     pub body: Blob,
-    pub content_type: String,
-    pub accept: String,
+    pub content_type: &'static str,
+    pub accept: &'static str,
     pub model_id: String,
 }
 
 impl BedrockCall {
-    fn new(body: Blob, content_type: String, accept: String, model_id: String) -> BedrockCall {
+    fn new(
+        body: &dyn Blobbable,
+        content_type: &'static str,
+        accept: &'static str,
+        model_id: String,
+    ) -> BedrockCall {
+        let body = body.to_blob();
         BedrockCall {
             body,
             content_type,
@@ -81,32 +90,32 @@ impl BedrockCall {
 // this will not necessarily be a 1-to-1 mapping. For example, minor
 // version updates to the model will have the same body, but differnet
 // values than in ArgModels. Thus, |ArgModels| >= |BedrockCallSum|.
-enum BedrockCallSum {
-    CohereBCS {
+enum ModelOptions {
+    Cohere {
         model_id: String,
         body: CohereBody,
     },
-    ClaudeBCS {
+    Claude {
         model_id: String,
         body: ClaudeBody,
     },
-    Claude3BCS {
+    Claude3 {
         model_id: String,
         body: ClaudeV3Body,
     },
-    Llama2BCS {
+    Llama2 {
         model_id: String,
         body: Llama2Body,
     },
-    Jurrasic2BCS {
+    Jurrasic2 {
         model_id: String,
         body: Jurrasic2Body,
     },
-    TitanTextBCS {
+    TitanText {
         model_id: String,
         body: TitanTextV1Body,
     },
-    Mistral7bBCS {
+    Mistral7b {
         model_id: String,
         body: Mistral7Body,
     },
@@ -115,60 +124,39 @@ enum BedrockCallSum {
 // Using a sum type to represent all models that can go through here.
 // This way if each model needs special processing to make a BedrockCall
 // that can be implemented in one place.
-fn bcs_to_bedrock_call(bcs: BedrockCallSum) -> Result<BedrockCall> {
+fn model_options_to_bedrock_call(bcs: ModelOptions) -> Result<BedrockCall> {
     match bcs {
-        BedrockCallSum::CohereBCS { model_id, body } => Ok(BedrockCall::new(
-            body.convert_to_blob()?,
-            "application/json".to_string(),
-            "*/*".to_string(),
-            model_id,
-        )),
-        BedrockCallSum::ClaudeBCS { model_id, body } => Ok(BedrockCall::new(
-            body.convert_to_blob()?,
-            "application/json".to_string(),
-            "*/*".to_string(),
-            model_id,
-        )),
-        BedrockCallSum::Claude3BCS { model_id, body } => Ok(BedrockCall::new(
-            body.convert_to_blob()?,
-            "application/json".to_string(),
-            "*/*".to_string(),
-            model_id,
-        )),
-        BedrockCallSum::Llama2BCS { model_id, body } => Ok(BedrockCall::new(
-            body.convert_to_blob()?,
-            "application/json".to_string(),
-            "*/*".to_string(),
-            model_id,
-        )),
-        BedrockCallSum::Jurrasic2BCS { model_id, body } => Ok(BedrockCall::new(
-            body.convert_to_blob()?,
-            "application/json".to_string(),
-            "*/*".to_string(),
-            model_id,
-        )),
-        BedrockCallSum::TitanTextBCS { model_id, body } => Ok(BedrockCall::new(
-            body.convert_to_blob()?,
-            "application/json".to_string(),
-            "*/*".to_string(),
-            model_id,
-        )),
-        BedrockCallSum::Mistral7bBCS { model_id, body } => Ok(BedrockCall::new(
-            body.convert_to_blob()?,
-            "application/json".to_string(),
-            "*/*".to_string(),
-            model_id,
-        )),
+        ModelOptions::Cohere { model_id, body } => {
+            Ok(BedrockCall::new(&body, "application/json", "*/*", model_id))
+        }
+        ModelOptions::Claude { model_id, body } => {
+            Ok(BedrockCall::new(&body, "application/json", "*/*", model_id))
+        }
+        ModelOptions::Claude3 { model_id, body } => {
+            Ok(BedrockCall::new(&body, "application/json", "*/*", model_id))
+        }
+        ModelOptions::Llama2 { model_id, body } => {
+            Ok(BedrockCall::new(&body, "application/json", "*/*", model_id))
+        }
+        ModelOptions::Jurrasic2 { model_id, body } => {
+            Ok(BedrockCall::new(&body, "application/json", "*/*", model_id))
+        }
+        ModelOptions::TitanText { model_id, body } => {
+            Ok(BedrockCall::new(&body, "application/json", "*/*", model_id))
+        }
+        ModelOptions::Mistral7b { model_id, body } => {
+            Ok(BedrockCall::new(&body, "application/json", "*/*", model_id))
+        }
     }
 }
 
-// Create a BedrockCallSum with sensible defaults for each model.
+// Create a `ModelOptions` with sensible defaults for each model.
 // This will fail if model_id is not known to q_to_bcs_with_defaults.
-fn q_to_bcs_with_defaults(
+fn convert_question_to_model_options(
     question: Option<String>,
     model_id: &str,
     image: Option<&Image>,
-) -> Result<BedrockCallSum, anyhow::Error> {
+) -> Result<ModelOptions, anyhow::Error> {
     // call the function to load model settings:
     let model_defaults = load_model_config()?;
 
@@ -182,7 +170,7 @@ fn q_to_bcs_with_defaults(
                 d.p,
                 d.max_gen_len,
             );
-            Ok(BedrockCallSum::Llama2BCS {
+            Ok(ModelOptions::Llama2 {
                 model_id: String::from("meta.llama2-70b-chat-v1"),
                 body: llama2_body,
             })
@@ -201,7 +189,7 @@ fn q_to_bcs_with_defaults(
                 d.stream,
             );
 
-            Ok(BedrockCallSum::CohereBCS {
+            Ok(ModelOptions::Cohere {
                 model_id: String::from("cohere.command-text-v14"),
                 body: cohere_body,
             })
@@ -216,7 +204,7 @@ fn q_to_bcs_with_defaults(
                 d.max_tokens,
                 d.stop_sequences,
             );
-            Ok(BedrockCallSum::Jurrasic2BCS {
+            Ok(ModelOptions::Jurrasic2 {
                 model_id: String::from("ai21.j2-ultra-v1"),
                 body: jurrasic_body,
             })
@@ -233,7 +221,7 @@ fn q_to_bcs_with_defaults(
                 d.max_tokens_to_sample,
                 d.stop_sequences,
             );
-            Ok(BedrockCallSum::ClaudeBCS {
+            Ok(ModelOptions::Claude {
                 model_id: String::from("anthropic.claude-v2"),
                 body: claude_body,
             })
@@ -257,7 +245,7 @@ fn q_to_bcs_with_defaults(
                 question,
                 claude_image,
             );
-            Ok(BedrockCallSum::Claude3BCS {
+            Ok(ModelOptions::Claude3 {
                 model_id: String::from("anthropic.claude-3-sonnet-20240229-v1:0"),
                 body: claudev3_body,
             })
@@ -281,7 +269,7 @@ fn q_to_bcs_with_defaults(
                 question,
                 claude_image,
             );
-            Ok(BedrockCallSum::Claude3BCS {
+            Ok(ModelOptions::Claude3 {
                 model_id: String::from("anthropic.claude-3-haiku-20240307-v1:0"),
                 body: claudev3_body,
             })
@@ -299,7 +287,7 @@ fn q_to_bcs_with_defaults(
                 d.max_tokens_to_sample,
                 d.stop_sequences,
             );
-            Ok(BedrockCallSum::ClaudeBCS {
+            Ok(ModelOptions::Claude {
                 model_id: String::from("anthropic.claude-v2:1"),
                 body: claude_body,
             })
@@ -315,7 +303,7 @@ fn q_to_bcs_with_defaults(
                 d.max_token_count,
                 d.stop_sequences,
             );
-            Ok(BedrockCallSum::TitanTextBCS {
+            Ok(ModelOptions::TitanText {
                 model_id: String::from("amazon.titan-text-express-v1"),
                 body: titan_body,
             })
@@ -330,7 +318,7 @@ fn q_to_bcs_with_defaults(
                 d.max_tokens,
                 d.stop,
             );
-            Ok(BedrockCallSum::Mistral7bBCS {
+            Ok(ModelOptions::Mistral7b {
                 model_id: String::from("mistral.mixtral-8x7b-instruct-v0:1"),
                 body: mixtral_body,
             })
@@ -345,7 +333,7 @@ fn q_to_bcs_with_defaults(
                 d.max_tokens,
                 d.stop,
             );
-            Ok(BedrockCallSum::Mistral7bBCS {
+            Ok(ModelOptions::Mistral7b {
                 model_id: String::from("mistral.mistral-7b-instruct-v0:2"),
                 body: mixtral_body,
             })
@@ -361,8 +349,8 @@ fn mk_bedrock_call(
     image: Option<&Image>,
     model_id: &str,
 ) -> Result<BedrockCall> {
-    let bcs = q_to_bcs_with_defaults(Some(question.to_string()), model_id, image)?;
-    bcs_to_bedrock_call(bcs)
+    let bcs = convert_question_to_model_options(Some(question.to_string()), model_id, image)?;
+    model_options_to_bedrock_call(bcs)
 }
 
 // Given a question and model_id, create and execute a call to bedrock.
@@ -402,9 +390,7 @@ pub async fn ask_bedrock(
                 let caption = call_bedrock(client, bcall, run_type).await?;
                 Ok(caption)
             } else {
-                Err(anyhow!(
-                    "No images provided. Captioning aborted."
-                ))
+                Err(anyhow!("No images provided. Captioning aborted."))
             }
         }
     }
@@ -424,7 +410,7 @@ fn process_response(
             | "anthropic.claude-3-haiku-20240307-v1:0" => {
                 serde_json::from_slice::<ClaudeV3Response>(payload_bytes)
                     .map(|res| res.content[0].text.clone())
-            },
+            }
             "ai21.j2-ultra-v1" => {
                 serde_json::from_slice::<Jurrasic2ResponseCompletions>(payload_bytes)
                     .map(|res| res.completions[0].data.text.clone())
@@ -493,7 +479,8 @@ async fn call_bedrock(
         .accept(c.accept)
         .model_id(&c.model_id)
         .send()
-        .await?;
+        .await
+        .map_err(give_bedrock_hints)?;
 
     let response_text = process_response(c.model_id.as_str(), response.body.as_ref(), false);
     match response_text {
@@ -508,7 +495,25 @@ async fn call_bedrock(
     }
 }
 
-async fn call_bedrock_stream(bc: &aws_sdk_bedrockruntime::Client, c: BedrockCall) -> Result<String, anyhow::Error> {
+fn give_bedrock_hints(err: impl Into<aws_sdk_bedrockruntime::Error>) -> anyhow::Error {
+    let err = err.into();
+    let context = match &err {
+        aws_sdk_bedrockruntime::Error::AccessDeniedException(_err) => {
+            Some("hint: Models must be enabled for a specific region! bedrust uses us-west-2.")
+        }
+        _ => None,
+    };
+    let mut anyhow_err: anyhow::Error = err.into();
+    if let Some(context) = context {
+        anyhow_err = anyhow_err.context(context);
+    }
+    anyhow_err
+}
+
+async fn call_bedrock_stream(
+    bc: &aws_sdk_bedrockruntime::Client,
+    c: BedrockCall,
+) -> Result<String, anyhow::Error> {
     let mut resp = bc
         .invoke_model_with_response_stream()
         .body(c.body)
@@ -516,7 +521,8 @@ async fn call_bedrock_stream(bc: &aws_sdk_bedrockruntime::Client, c: BedrockCall
         .accept(c.accept)
         .model_id(&c.model_id)
         .send()
-        .await?;
+        .await
+        .map_err(give_bedrock_hints)?;
 
     let mut output = String::new();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -495,11 +495,12 @@ async fn call_bedrock(
     }
 }
 
+/// Add context and advice for specific error variants
 fn give_bedrock_hints(err: impl Into<aws_sdk_bedrockruntime::Error>) -> anyhow::Error {
     let err = err.into();
     let context = match &err {
         aws_sdk_bedrockruntime::Error::AccessDeniedException(_err) => {
-            Some("hint: Models must be enabled for a specific region! bedrust uses us-west-2.")
+            Some("hint: If you belive you have enabled this model, note that access MUST be enabled for a specific region!")
         }
         _ => None,
     };
@@ -507,6 +508,8 @@ fn give_bedrock_hints(err: impl Into<aws_sdk_bedrockruntime::Error>) -> anyhow::
     if let Some(context) = context {
         anyhow_err = anyhow_err.context(context);
     }
+    anyhow_err = anyhow_err.context("failed to invoke bedrock");
+
     anyhow_err
 }
 

--- a/src/models/claude.rs
+++ b/src/models/claude.rs
@@ -1,5 +1,3 @@
-use anyhow::Result;
-use aws_sdk_bedrockruntime::primitives::Blob;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -47,12 +45,6 @@ impl ClaudeBody {
             max_tokens_to_sample,
             stop_sequences,
         }
-    }
-
-    pub fn convert_to_blob(&self) -> Result<Blob> {
-        let blob_string = serde_json::to_vec(&self)?;
-        let body: Blob = Blob::new(blob_string.clone());
-        Ok(body)
     }
 }
 

--- a/src/models/claudev3.rs
+++ b/src/models/claudev3.rs
@@ -1,5 +1,3 @@
-use anyhow::Result;
-use aws_sdk_bedrockruntime::primitives::Blob;
 use serde::{ser::SerializeStruct, Deserialize, Serialize};
 
 #[derive(Debug)]
@@ -127,12 +125,6 @@ impl ClaudeV3Body {
             max_tokens,
             messages: vec![message],
         }
-    }
-
-    pub fn convert_to_blob(&self) -> Result<Blob> {
-        let blob_string = serde_json::to_vec(&self)?;
-        let body: Blob = Blob::new(blob_string.clone());
-        Ok(body)
     }
 }
 

--- a/src/models/cohere.rs
+++ b/src/models/cohere.rs
@@ -1,4 +1,3 @@
-use anyhow::Result;
 use aws_sdk_bedrockruntime::primitives::Blob;
 use serde::{Deserialize, Serialize};
 
@@ -43,11 +42,20 @@ impl CohereBody {
             stream,
         }
     }
+}
 
-    pub fn convert_to_blob(&self) -> Result<Blob> {
-        let blob_string = serde_json::to_vec(&self)?;
-        let body: Blob = Blob::new(blob_string);
-        Ok(body)
+pub(crate) trait Blobbable {
+    fn to_blob(&self) -> Blob;
+}
+
+impl<T> Blobbable for T
+where
+    T: Serialize,
+{
+    fn to_blob(&self) -> Blob {
+        let blob_string =
+            serde_json::to_vec(&self).expect("unserializable settings. this is a bug.");
+        Blob::new(blob_string)
     }
 }
 

--- a/src/models/jurrasic2.rs
+++ b/src/models/jurrasic2.rs
@@ -1,5 +1,3 @@
-use anyhow::Result;
-use aws_sdk_bedrockruntime::primitives::Blob;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -35,12 +33,6 @@ impl Jurrasic2Body {
             max_tokens,
             stop_sequences,
         }
-    }
-
-    pub fn convert_to_blob(&self) -> Result<Blob> {
-        let blob_string = serde_json::to_vec(&self)?;
-        let body: Blob = Blob::new(blob_string);
-        Ok(body)
     }
 }
 

--- a/src/models/llama2.rs
+++ b/src/models/llama2.rs
@@ -1,5 +1,3 @@
-use anyhow::Result;
-use aws_sdk_bedrockruntime::primitives::Blob;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -25,12 +23,6 @@ impl Llama2Body {
             top_p,
             max_gen_len,
         }
-    }
-
-    pub fn convert_to_blob(&self) -> Result<Blob> {
-        let blob_string = serde_json::to_vec(&self)?;
-        let body: Blob = Blob::new(blob_string);
-        Ok(body)
     }
 }
 

--- a/src/models/mistral.rs
+++ b/src/models/mistral.rs
@@ -1,5 +1,3 @@
-use anyhow::Result;
-use aws_sdk_bedrockruntime::primitives::Blob;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -46,12 +44,6 @@ impl Mistral7Body {
             max_tokens,
             stop,
         }
-    }
-
-    pub fn convert_to_blob(&self) -> Result<Blob> {
-        let blob_string = serde_json::to_vec(&self)?;
-        let body: Blob = Blob::new(blob_string);
-        Ok(body)
     }
 }
 

--- a/src/models/titan.rs
+++ b/src/models/titan.rs
@@ -1,5 +1,3 @@
-use anyhow::Result;
-use aws_sdk_bedrockruntime::primitives::Blob;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -44,12 +42,6 @@ impl TitanTextV1Body {
             input_text,
             text_generation_config: text_gen_config,
         }
-    }
-
-    pub fn convert_to_blob(&self) -> Result<Blob> {
-        let blob_string = serde_json::to_vec(&self)?;
-        let body: Blob = Blob::new(blob_string);
-        Ok(body)
     }
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,8 +1,10 @@
 use anyhow::anyhow;
-use clap::Parser;
+use clap::{Parser, ValueEnum};
+use dialoguer::{theme::ColorfulTheme, FuzzySelect};
 use figlet_rs::FIGfont;
+use ron::ser::PrettyConfig;
 
-use std::{fs, path::PathBuf};
+use std::{fmt::Display, fs, path::PathBuf};
 use termcolor::{Color, ColorChoice, ColorSpec, StandardStream, WriteColor};
 
 use serde::{Deserialize, Serialize};
@@ -21,7 +23,7 @@ pub struct Args {
     pub init: bool,
 
     #[clap(value_enum)]
-    #[arg(short, long, required_unless_present("init"))]
+    #[arg(short, long)]
     pub model_id: Option<ArgModels>,
 
     #[arg(short, long)]
@@ -36,9 +38,10 @@ pub struct BedrustConfig {
     pub aws_profile: String,
     pub supported_images: Vec<String>,
     pub caption_prompt: String,
+    pub default_model: Option<ArgModels>,
 }
 
-#[derive(clap::ValueEnum, Clone)]
+#[derive(clap::ValueEnum, Clone, Serialize, Deserialize, Debug, Copy)]
 pub enum ArgModels {
     Llama270b,
     CohereCommand,
@@ -50,6 +53,12 @@ pub enum ArgModels {
     TitanTextExpressV1,
     Mixtral8x7bInstruct,
     Mistral7bInstruct,
+}
+
+impl Display for ArgModels {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.to_str())
+    }
 }
 
 impl ArgModels {
@@ -77,7 +86,7 @@ pub fn hello_header(s: &str) -> Result<(), anyhow::Error> {
     let figlet_path_str = figlet_font_file_path
         .as_path()
         .to_str()
-        .ok_or_else(||anyhow!("Was unable to parse Figlet font path to string"))?;
+        .ok_or_else(|| anyhow!("Was unable to parse Figlet font path to string"))?;
     let ansi_font = FIGfont::from_file(figlet_path_str).unwrap();
     let hello = ansi_font.convert(s);
 
@@ -86,10 +95,18 @@ pub fn hello_header(s: &str) -> Result<(), anyhow::Error> {
     println!("{}", hello.unwrap());
     stdout.set_color(ColorSpec::new().set_fg(Some(Color::White)))?;
     println!("{}", "----------------------------------------".cyan());
-    println!("{}", "Currently supported chat commands: ".truecolor(83,82,82));
+    println!(
+        "{}",
+        "Currently supported chat commands: ".truecolor(83, 82, 82)
+    );
     println!("{}", "/q\t \t - Quit".truecolor(255, 229, 153));
     println!("{}", "----------------------------------------".cyan());
-    println!("{}{}{} 💬", "Now with ".italic(), "CHAT".red().on_yellow().blink(), " enabled!".italic());
+    println!(
+        "{}{}{} 💬",
+        "Now with ".italic(),
+        "CHAT".red().on_yellow().blink(),
+        " enabled!".italic()
+    );
 
     Ok(())
 }
@@ -118,53 +135,69 @@ pub fn check_for_config() -> Result<bool, anyhow::Error> {
 
     if !bedrust_config_file_path.exists() || !model_config_file_path.exists() {
         Ok(false)
-    } else { 
+    } else {
         Ok(true)
     }
+}
 
+pub fn prompt_for_model_selection() -> Result<ArgModels, anyhow::Error> {
+    let model_list = ArgModels::value_variants();
+    let idx = FuzzySelect::with_theme(&ColorfulTheme::default())
+        .with_prompt("Select a default model to use or <enter> to skip")
+        .items(model_list)
+        .interact()?;
+    Ok(model_list[idx])
+}
+
+pub fn prompt_for_model_selection_opt() -> Result<Option<ArgModels>, anyhow::Error> {
+    let model_list = ArgModels::value_variants();
+    let idx = FuzzySelect::with_theme(&ColorfulTheme::default())
+        .with_prompt("Select a default model to use or <enter> to skip")
+        .items(model_list)
+        .interact_opt()?;
+    Ok(idx.map(|idx|model_list[idx]))
 }
 
 // function that creates the configuration files during the `init` command
-pub fn initialize_config() -> Result<(), anyhow::Error>{
+pub fn initialize_config() -> Result<(), anyhow::Error> {
     let home_dir = home_dir().expect("Failed to get HOME directory");
     let config_dir = home_dir.join(format!(".config/{}", constants::CONFIG_DIR_NAME));
     fs::create_dir_all(&config_dir)?;
 
     let bedrust_config_file_path = config_dir.join(constants::BEDRUST_CONFIG_FILE_NAME);
     let bedrust_config_content = constants::BEDRUST_CONFIG_FILE.to_string();
-    fs::write(&bedrust_config_file_path, bedrust_config_content)?;
-    println!("⏳| Bedrust configuration file created at: {:?}", bedrust_config_file_path);
+
+    let mut default_config: BedrustConfig =
+        ron::de::from_str(&bedrust_config_content).expect("default config must be valid");
+    default_config.default_model = prompt_for_model_selection_opt()?;
+
+    fs::write(
+        &bedrust_config_file_path,
+        ron::ser::to_string_pretty(&default_config, PrettyConfig::new())?,
+    )?;
+    println!(
+        "⏳| Bedrust configuration file created at: {:?}",
+        bedrust_config_file_path
+    );
     println!("This file is used to store configuration items for the bedrust application.");
 
     let model_config_file_path = config_dir.join(constants::MODEL_CONFIG_FILE_NAME);
     let model_config_content = constants::MODEL_CONFIG_FILE.to_string();
     fs::write(&model_config_file_path, model_config_content)?;
-    println!("⏳| Model configuration file created at: {:?}", model_config_file_path);
+    println!(
+        "⏳| Model configuration file created at: {:?}",
+        model_config_file_path
+    );
     println!("This file is used to store default model parameters such as max tokens, temperature, top_p, top_k, etc.");
 
     let figlet_font_file_path = config_dir.join(constants::FIGLET_FONT_FILENAME);
     let figlet_font_content = constants::FIGLET_FONT;
     fs::write(&figlet_font_file_path, figlet_font_content)?;
     println!("⏳| Figlet font created at: {:?}", figlet_font_file_path);
-    println!("This file is used to as a font for `figlet` to create the nice big font during launch.");
+    println!(
+        "This file is used to as a font for `figlet` to create the nice big font during launch."
+    );
 
     println!("✅ | Bedrust configuration has been initialized in ~/.config/bedrust. You may now use it as normal.");
     Ok(())
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -143,7 +143,7 @@ pub fn check_for_config() -> Result<bool, anyhow::Error> {
 pub fn prompt_for_model_selection() -> Result<ArgModels, anyhow::Error> {
     let model_list = ArgModels::value_variants();
     let idx = FuzzySelect::with_theme(&ColorfulTheme::default())
-        .with_prompt("Select a default model to use or <enter> to skip")
+        .with_prompt("Select a model to use:")
         .items(model_list)
         .interact()?;
     Ok(model_list[idx])
@@ -152,7 +152,7 @@ pub fn prompt_for_model_selection() -> Result<ArgModels, anyhow::Error> {
 pub fn prompt_for_model_selection_opt() -> Result<Option<ArgModels>, anyhow::Error> {
     let model_list = ArgModels::value_variants();
     let idx = FuzzySelect::with_theme(&ColorfulTheme::default())
-        .with_prompt("Select a default model to use or <enter> to skip")
+        .with_prompt("Select a default model to use press <enter> to skip")
         .items(model_list)
         .interact_opt()?;
     Ok(idx.map(|idx|model_list[idx]))


### PR DESCRIPTION
1. First commit: a few cleanups. In the long term, I would probably recommend using a trait to express the model options, parsing etc. Given the large number of variants, this may be a little cleaner. I also added an error hint on access denied errors. I also renamed a few structs/enums to be a little more idiomatic

2. Add the ability to select a default model. If model-id is not set, and there is no default model, I fall back to prompting the user.